### PR TITLE
[Feat::router] use file stem intead of file title for route

### DIFF
--- a/app/src/routes.rs
+++ b/app/src/routes.rs
@@ -15,7 +15,7 @@ fn switch(routes: &RootRoutes) -> Html {
         RootRoutes::Home | RootRoutes::Root => html! { <Home /> },
         RootRoutes::Projects => html! { <Projects /> },
         RootRoutes::About => html! { <About /> },
-        RootRoutes::Post { title } => html! {<Post encoded_title={title.clone()} />},
+        RootRoutes::Post { filename } => html! {<Post filename={filename.clone()} />},
         RootRoutes::NotFound => html! { <NotFound />},
         RootRoutes::Links => html! {<Links />},
     }

--- a/pages/links/src/lib.rs
+++ b/pages/links/src/lib.rs
@@ -88,7 +88,7 @@ pub fn links() -> Html {
                 <div class="banner__links">
                     <div class="banner__links-title">{"友情链接"}</div>
                     <div class="banner__links-desc">{"这里放置大家的博客 & 个人网站，拒绝广告，欢迎各类应用，如果你想跟我交换友情链接，直接戳 "}
-                        <Link href={RootRoutes::Post {title: String::from("如何申请友情链接")}}>{"这里"}</Link>
+                        <Link href={RootRoutes::Post {filename: String::from("add_links")}}>{"这里"}</Link>
                     {" 来进行交换吧。"}</div>
                 </div>
             </div>

--- a/pages/post/src/lib.rs
+++ b/pages/post/src/lib.rs
@@ -7,14 +7,12 @@ use yew::prelude::*;
 
 #[derive(Properties, Clone, PartialEq)]
 pub struct PostProps {
-    pub encoded_title: String,
+    pub filename: String,
 }
 
 #[function_component(Post)]
 pub fn post(props: &PostProps) -> Html {
-    let post = POST_SERVICE
-        .find_post_by_encoded_title(&props.encoded_title)
-        .unwrap();
+    let post = POST_SERVICE.find_post_by_filename(&props.filename).unwrap();
     let style = style!(
         r#"
         width: 660px;

--- a/router/src/lib.rs
+++ b/router/src/lib.rs
@@ -4,8 +4,8 @@ use yew_router::prelude::*;
 pub enum RootRoutes {
     #[at("/home")]
     Home,
-    #[at("/posts/:title")]
-    Post { title: String },
+    #[at("/posts/:filename")]
+    Post { filename: String },
     #[at("/")]
     Root,
     #[at("/projects")]

--- a/services/src/post_service/post_service.rs
+++ b/services/src/post_service/post_service.rs
@@ -4,7 +4,6 @@ use chrono::NaiveDateTime;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::cmp::Ordering;
-use urlencoding::encode;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Post {
@@ -12,6 +11,7 @@ pub struct Post {
     pub raw_content: &'static str,
     pub desc: String,
     pub modified_time: String,
+    pub filename: &'static str,
 }
 
 pub struct PostService {
@@ -57,15 +57,11 @@ impl PostService {
             .into_owned()
     }
 
-    pub fn find_post_by_title(&self, title: &str) -> Option<Post> {
-        self.find_post_by_encoded_title(encode(title).to_string().as_str())
-    }
-
-    pub fn find_post_by_encoded_title(&self, title: &str) -> Option<Post> {
+    pub fn find_post_by_filename(&self, filename: &str) -> Option<Post> {
         self.posts
             .clone()
             .into_iter()
-            .find(|post| encode(post.metadata.title.as_str()) == title)
+            .find(|post| post.filename == filename)
     }
 
     pub fn get_tags(&self) -> Vec<String> {
@@ -121,6 +117,7 @@ impl PostService {
                     raw_content: post.content,
                     desc,
                     modified_time,
+                    filename: post.filename,
                 }
             })
             .collect::<Vec<Post>>();

--- a/services/src/posts.rs
+++ b/services/src/posts.rs
@@ -3,17 +3,20 @@ use std::*;
 #[derive(Clone)]
 pub struct PostFile {
     pub content: &'static str,
-    pub modified_time: u128
+    pub modified_time: u128,
+    pub filename: &'static str
 }
 
 pub static POSTS: [PostFile; 2] = [
     PostFile {
     content: include_str!("../../posts/build_blog.md"),
-    modified_time: 1654609915763
+    modified_time: 1654609915763,
+    filename: "build_blog"
 },
 PostFile {
     content: include_str!("../../posts/add_links.md"),
-    modified_time: 1654855461934
+    modified_time: 1654855511389,
+    filename: "add_links"
 },
 
 ];

--- a/services/src/projects_service/projects_service.rs
+++ b/services/src/projects_service/projects_service.rs
@@ -37,7 +37,7 @@ impl ProjectsService {
             .iter()
             .map(|raw_project| {
                 let post = match raw_project.post.clone() {
-                    Some(post_title) => POST_SERVICE.find_post_by_title(&post_title).clone(),
+                    Some(filename) => POST_SERVICE.find_post_by_filename(&filename).clone(),
                     None => None,
                 };
 

--- a/templates/md_parser.template
+++ b/templates/md_parser.template
@@ -3,7 +3,8 @@ use std::*;
 #[derive(Clone)]
 pub struct PostFile {
     pub content: &'static str,
-    pub modified_time: u128
+    pub modified_time: u128,
+    pub filename: &'static str
 }
 
 pub static POSTS: [PostFile; {{TRAVERSE_COUNT}}] = [

--- a/templates/md_parser_iteration.template
+++ b/templates/md_parser_iteration.template
@@ -1,4 +1,5 @@
 PostFile {
     content: include_str!("../../posts/{{STEM}}.md"),
-    modified_time: {{MODIFY_TIME}}
+    modified_time: {{MODIFY_TIME}},
+    filename: "{{STEM}}"
 },

--- a/ui/src/post_card/post_card_large.rs
+++ b/ui/src/post_card/post_card_large.rs
@@ -81,7 +81,7 @@ pub fn post_card_large(props: &PostCardLargeProps) -> Html {
     let post_encoded_title = encode(props.post.metadata.title.as_str());
 
     html! {
-        <Link href={RootRoutes::Post{title: post_encoded_title.to_string()}}>
+        <Link href={RootRoutes::Post{filename: props.post.filename.to_string()}}>
         <div class={style}>
             <div class="cover" />
             <div class="post-preview">

--- a/ui/src/post_card/post_card_small.rs
+++ b/ui/src/post_card/post_card_small.rs
@@ -3,7 +3,6 @@ use crate::post_card_header::PostCardHeader;
 use router::RootRoutes;
 use services::post_service::post_service::Post;
 use stylist::style;
-use urlencoding::encode;
 use yew::prelude::*;
 
 #[derive(Properties, Clone, PartialEq)]
@@ -81,11 +80,10 @@ pub fn post_card_small(props: &PostCardProps) -> Html {
         cover = props.post.metadata.cover.clone()
     )
     .unwrap();
-    let post_encoded_title = encode(props.post.metadata.title.as_str());
 
     html! {
         <div class={style}>
-            <Link href={RootRoutes::Post{title: post_encoded_title.to_string()}}>
+            <Link href={RootRoutes::Post{filename: props.post.filename.to_string()}}>
                 <div class="wrapper">
                     <PostCardHeader label={props.post.metadata.tag.clone()} />
                     <div class="cover" />

--- a/ui/src/project_card.rs
+++ b/ui/src/project_card.rs
@@ -2,7 +2,6 @@ use crate::link::Link;
 use router::RootRoutes;
 use services::projects_service::projects_service::Project;
 use stylist::style;
-use urlencoding::encode;
 use yew::prelude::*;
 
 #[derive(Properties, Clone, PartialEq)]
@@ -74,10 +73,8 @@ pub fn project_card(props: &ProjectCardProps) -> Html {
             {
                 match &props.project.post {
                     Some(post) => {
-                        let encoded_title = encode(post.metadata.title.as_str()).to_string();
-
                         html! {
-                            <Link href={RootRoutes::Post {title: encoded_title }}>
+                            <Link href={RootRoutes::Post {filename: post.filename.to_string() }}>
                                 <div class="post-block">
                                     <div class="summary">
                                         {&post.desc}


### PR DESCRIPTION
Use file stem intead of encoded file title for route:

**Before**
```
https://www.zzhack.fun/posts/%E6%9E%84%E5%BB%BA%E9%9D%99%E6%80%81%E7%BA%AF%E7%B2%B9%E7%9A%84%E5%8D%9A%E5%AE%A2%E7%AB%99%E7%82%B9 
```

**After**
```
https://www.zzhack.fun/posts/posts/build_blog
```